### PR TITLE
Stop using deprecated Buffer constructor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ msg.push({ foo: 'bar' });
 console.log(msg.toBuffer());
 // => <Buffer 14 00 05 73 3a 66 6f 6f 00 05 73 3a 62 61 72 00 05 73 3a 62 61 7a 00 0f 6a 3a 7b 22 66 6f 6f 22 3a 22 62 61 72 22 7d>
 
-msg.push(new Buffer('image data'));
+msg.push(Buffer.from('image data'));
 console.log(msg.toBuffer());
 // => <Buffer 15 00 05 73 3a 66 6f 6f 00 05 73 3a 62 61 72 00 05 73 3a 62 61 7a 00 0f 6a 3a 7b 22 66 6f 6f 22 3a 22 62 61 72 22 7d 00 0a 69 6d 61 67 65 20 64 61 74 ... >
 ```
@@ -45,7 +45,7 @@ var msg = new Message;
 
 msg.push('foo')
 msg.push({ hello: 'world' })
-msg.push(new Buffer('hello'))
+msg.push(Buffer.from('hello'))
 
 var other = new Message(msg.toBuffer());
 

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -7,15 +7,15 @@ var msg = new Message;
 
 msg.push('foo')
 msg.push({ foo: 'bar' })
-msg.push(new Buffer('something'))
+msg.push(Buffer.from('something'))
 
 // buffer message
 
 var bufmsg = new Message;
 
-bufmsg.push(new Buffer('foo'))
-bufmsg.push(new Buffer('bar'))
-bufmsg.push(new Buffer('baz'))
+bufmsg.push(Buffer.from('foo'))
+bufmsg.push(Buffer.from('bar'))
+bufmsg.push(Buffer.from('baz'))
 
 // string message
 

--- a/examples/pack.js
+++ b/examples/pack.js
@@ -13,5 +13,5 @@ console.log(msg.toBuffer());
 msg.push({ foo: 'bar' });
 console.log(msg.toBuffer());
 
-msg.push(new Buffer('image data'));
+msg.push(Buffer.from('image data'));
 console.log(msg.toBuffer());

--- a/examples/unpack.js
+++ b/examples/unpack.js
@@ -1,7 +1,7 @@
 
 var Message = require('..');
 
-var msg = new Message(['foo', { foo: 'bar' }, new Buffer('foo')]);
+var msg = new Message(['foo', { foo: 'bar' }, Buffer.from('foo')]);
 
 msg = new Message(msg.toBuffer());
 

--- a/index.js
+++ b/index.js
@@ -117,13 +117,13 @@ function pack(arg) {
   if (Buffer.isBuffer(arg)) return arg;
 
   // string
-  if ('string' == typeof arg) return new Buffer('s:' + arg);
+  if ('string' == typeof arg) return Buffer.from('s:' + arg);
 
   // undefined
   if (arg === undefined) arg = null;
 
   // json
-  return new Buffer('j:' + JSON.stringify(arg));
+  return Buffer.from('j:' + JSON.stringify(arg));
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ describe('Message(buffer)', function(){
 
     msg.push('foo');
     msg.push({ foo: 'bar' });
-    msg.push(new Buffer('bar'));
+    msg.push(Buffer.from('bar'));
 
     msg = new Message(msg.toBuffer());
 


### PR DESCRIPTION
The `new Buffer(string|number)` form was deemed an attack vector and deprecated. All Node.js v6.x+ versions have the `.from()`, `.alloc()` and `.allocUnsafe()` family of Buffer methods now.